### PR TITLE
Added support for uint*_t types, fixed parsing of int*_t types in C

### DIFF
--- a/piton.dtx
+++ b/piton.dtx
@@ -3371,8 +3371,8 @@ piton_version = "4.7x" -- 2025/07/10
 % \texttt{!= == << >> - \~{} + / * \% = < > \& .} \verb+|+ \verb|@| \\ 
 % Name.Type & the following predefined types:
 %   |bool|, |char|, |char16_t|, |char32_t|, |double|, |float|, |int|, |int8_t|,
-%   |int16_t|, |int32_t|, |int64_t|, |long|, |short|, |signed|, |unsigned|,
-%   |void| et |wchar_t| \\  
+%   |int16_t|, |int32_t|, |int64_t|, |uint8_t|, |uint16_t|, |uint32_t|, |uint64_t|,
+%   |long|, |short|, |signed|, |unsigned|, |void| et |wchar_t| \\  
 % Name.Builtin & the following predefined functions: |printf|, |scanf|,
 % |malloc|, |sizeof| and |alignof|  \\ 
 % Name.Class & le nom des classes au moment de leur définition, c'est-à-dire
@@ -9362,9 +9362,10 @@ do
 
   local Type = 
     K ( 'Name.Type' ,
-        P "bool" + "char" + "char16_t" + "char32_t" + "double" + "float" + "int" +
-        "int8_t" + "int16_t" + "int32_t" + "int64_t" + "long" + "short" + "signed"
-        + "unsigned" + "void" + "wchar_t" ) * Q "*" ^ 0 
+        P "bool" + "char" + "char16_t" + "char32_t" + "double" + "float" +
+        "int8_t" + "int16_t" + "int32_t" + "int64_t" + "uint8_t" + "uint16_t" +
+        "uint32_t" + "uint64_t" + "int" + "long" + "short" + "signed" + "unsigned" +
+        "void" + "wchar_t" ) * Q "*" ^ 0 
 
   local DefFunction = 
     Type 

--- a/piton.lua
+++ b/piton.lua
@@ -1041,9 +1041,10 @@ do
 
   local Type =
     K ( 'Name.Type' ,
-        P "bool" + "char" + "char16_t" + "char32_t" + "double" + "float" + "int" +
-        "int8_t" + "int16_t" + "int32_t" + "int64_t" + "long" + "short" + "signed"
-        + "unsigned" + "void" + "wchar_t" ) * Q "*" ^ 0
+        P "bool" + "char" + "char16_t" + "char32_t" + "double" + "float" +
+        "int8_t" + "int16_t" + "int32_t" + "int64_t" + "uint8_t" + "uint16_t" +
+        "uint32_t" + "uint64_t" + "int" + "long" + "short" + "signed" + "unsigned" +
+        "void" + "wchar_t" ) * Q "*" ^ 0
 
   local DefFunction =
     Type


### PR DESCRIPTION
Hi !

I noticed that under certain circumstances, the following C code was badly parsed:

```c
  typedef t1 int8_t;
  typedef t2 uint8_t;
```

The first is badly parsed because the int type is recognized before we can get to the int8_t type. As for the second, they were not on the list of type keywords.

My changes consist of :
- putting `int` after `int*_t` in the list (it seems that LPEG checks the possible substrings in order),
- adding `uint*_t` types to the list.

Let me know what you think !