### PR TITLE
Adding support for hexadecimal, octal and binary numbers.

### DIFF
--- a/piton.dtx
+++ b/piton.dtx
@@ -7592,7 +7592,10 @@ local Identifier = K ( 'Identifier.Internal' , identifier )
 %    \begin{macrocode}
 local Number =
   K ( 'Number.Internal' ,
-      ( digit ^ 1 * P "." * # ( 1 - P "." ) * digit ^ 0 
+      (P "0x" + P "0X") * (R "af" + R "AF" + digit) ^ 1
+      + (P "0o" + P "0O") * R "07" ^ 1
+      + (P "0b" + P "0B") * R "01" ^ 1
+      + ( digit ^ 1 * P "." * # ( 1 - P "." ) * digit ^ 0 
         + digit ^ 0 * P "." * digit ^ 1 
         + digit ^ 1 )
       * ( S "eE" * S "+-" ^ -1 * digit ^ 1 ) ^ -1

--- a/piton.lua
+++ b/piton.lua
@@ -96,7 +96,10 @@ local identifier = letter * alphanum ^ 0
 local Identifier = K ( 'Identifier.Internal' , identifier )
 local Number =
   K ( 'Number.Internal' ,
-      ( digit ^ 1 * P "." * # ( 1 - P "." ) * digit ^ 0
+      (P "0x" + P "0X") * (R "af" + R "AF" + digit) ^ 1
+      + (P "0o" + P "0O") * R "07" ^ 1
+      + (P "0b" + P "0B") * R "01" ^ 1
+      + ( digit ^ 1 * P "." * # ( 1 - P "." ) * digit ^ 0
         + digit ^ 0 * P "." * digit ^ 1
         + digit ^ 1 )
       * ( S "eE" * S "+-" ^ -1 * digit ^ 1 ) ^ -1


### PR DESCRIPTION
Bonjour !

Je continue à passer mon cours de minted à piton, et je viens de voir que les nombres hexadécimaux, octals et binaires ne sont pas correctement parsés (par exemple dans `0x12A`, seul le `0` initial a la bonne couleur). Ce pull request ajoute cette fonctionnalité pour tous les langages (y compris ceux qui ne peuvent pas les supporter en pratique, par exemple C ne reconnaît pas les littéraux binaires de la forme `0b10010`).

Dites-moi si cela vous convient !