### PR TITLE
Added support for hyperref links for line labels

### DIFF
--- a/piton.dtx
+++ b/piton.dtx
@@ -4408,9 +4408,13 @@ piton_version = "4.7x" -- 2025/07/10
             { 
               { \int_use:N \g_@@_visual_line_int } 
               { \thepage } 
+              { } 
+              { line.#1 } 
+              { } 
             } 
           } 
         \@esphack
+        \@ifpackageloaded{hyperref}{\Hy@raisedlink{\hyper@anchorstart{line.#1}\hyper@anchorend}}{}
       }
       { \@@_error:n { label~with~lines~numbers } }
   }

--- a/piton.sty
+++ b/piton.sty
@@ -269,9 +269,13 @@
             {
               { \int_use:N \g__piton_visual_line_int }
               { \thepage }
+              { }
+              { line.#1 }
+              { }
             }
           }
         \@esphack
+        \@ifpackageloaded{hyperref}{\Hy@raisedlink{\hyper@anchorstart{line.#1}\hyper@anchorend}}{}
       }
       { \__piton_error:n { label~with~lines~numbers } }
   }


### PR DESCRIPTION
Bonjour !

Je propose d'ajouter à l'alias de `\label` définit à l'intérieur des commentaires `LaTeX` de Piton les informations nécessaires à `hyperref` pour que les `\ref` vers des labels contenus dans un environnement `Piton` deviennent cliquables dans le PDF final.

Qu'en pensez-vous ?