### PR TITLE
Added support for zref labels to reference line numbers

### DIFF
--- a/piton-french.tex
+++ b/piton-french.tex
@@ -2086,9 +2086,10 @@ commentaire LaTeX.\footnote{Cette fonctionnalité est implémentée en redéfini
   les environnements |{Piton}|, la commande |\label|. Il peut donc y avoir des
   incompatibilités avec les extensions qui redéfinissent (globalement) cette commande
   |\label| (comme \pkg{varioref}, \pkg{refcheck}, \pkg{showlabels}, etc.)}
-
-
-
+De même, la commande |\zlabel| du paquetage \pkg{zref} peut être utilisée.\footnote{
+  Y compris la commande |\zcref| de \pkg{zref-clever}.}
+L'option globale |label-as-zlabel| permet d'utiliser |\label| à la place de |\zlabel| dans
+les commentaires LaTeX (ce qui est le comportement par défaut de \pkg{zref} en général).
 
 \subsubsection{La clé «math-comments»}
 

--- a/piton.dtx
+++ b/piton.dtx
@@ -7402,7 +7402,8 @@ piton_version = "4.7x" -- 2025/07/10
 \@@_msg_new:nn { label~with~lines~numbers } 
   {
     You~can't~use~the~command~\token_to_str:N \label\
-    because~the~key~'line-numbers'~is~not~active.\\
+    or~\token_to_str:N \zlabel\ because~the~key~'line-numbers'
+    ~is~not~active.\\
     If~you~go~on,~that~command~will~ignored.
   }
 %    \end{macrocode}

--- a/piton.dtx
+++ b/piton.dtx
@@ -3882,7 +3882,7 @@ piton_version = "4.7x" -- 2025/07/10
 % inside |Piton| environments to be replaced by a |\zlabel|-compatible command
 % (which is the default behavior of \pkg{zref} outside of such environments).
 %    \begin{macrocode}
-\bool_new:N \g__piton_zlabel_as_label_bool
+\bool_new:N \g_@@_zlabel_as_label_bool
 %    \end{macrocode}
 % 
 % \bigskip
@@ -3899,7 +3899,7 @@ piton_version = "4.7x" -- 2025/07/10
     beamer .default:n = true , 
     beamer .usage:n = load ,
 
-    label-as-zlabel .bool_gset:N = \g__@@_zlabel_as_label_bool ,
+    label-as-zlabel .bool_gset:N = \g_@@_zlabel_as_label_bool ,
     label-as-zlabel .default:n = true ,
     label-as-zlabel .initial:n = false ,
     label-as-zlabel .usage:n = load ,
@@ -3909,7 +3909,7 @@ piton_version = "4.7x" -- 2025/07/10
 %    \end{macrocode}
 % 
 %    \begin{macrocode}
-\__piton_msg_new:nn { Unknown~key~for~package }
+\__@@_msg_new:nn { Unknown~key~for~package }
   {
     Unknown~key.\\
     You~have~used~the~key~'\l_keys_key_str'~when~loading~piton~
@@ -3951,7 +3951,7 @@ piton_version = "4.7x" -- 2025/07/10
   }
 \hook_gput_code:nnn { begindocument } { . }
   {
-    \bool_if:NT \g__piton_zlabel_as_label_bool
+    \bool_if:NT \g_@@_zlabel_as_label_bool
     {
       \IfPackageLoadedTF { zref-base }
       { }
@@ -4469,7 +4469,7 @@ piton_version = "4.7x" -- 2025/07/10
         \protected@write \@auxout { }
           {
             \string\zref@newlabel {#1}{%
-              \string\default{\number\g__@@_visual_line_int}%
+              \string\default{\number\g_@@_visual_line_int}%
               \string\page{\thepage}%
               \string\zc@type{line}%
               \string\anchor{line.#1}%
@@ -5789,7 +5789,7 @@ piton_version = "4.7x" -- 2025/07/10
     \dim_zero:N \parindent 
     \dim_zero:N \lineskip
     \IfPackageLoadedTF{zref-base}{%
-      \bool_if:NTF { \g__@@_zlabel_as_label_bool }
+      \bool_if:NTF { \g_@@_zlabel_as_label_bool }
         { \cs_set_eq:NN \label \__@@_zlabel:n }
         { \cs_set_eq:NN \label \__@@_label:n }%
     }{%

--- a/piton.dtx
+++ b/piton.dtx
@@ -7402,8 +7402,7 @@ piton_version = "4.7x" -- 2025/07/10
 \@@_msg_new:nn { label~with~lines~numbers } 
   {
     You~can't~use~the~command~\token_to_str:N \label\
-    or~\token_to_str:N \zlabel\ because~the~key~'line-numbers'
-    ~is~not~active.\\
+    because~the~key~'line-numbers'~is~not~active.\\
     If~you~go~on,~that~command~will~ignored.
   }
 %    \end{macrocode}

--- a/piton.dtx
+++ b/piton.dtx
@@ -2070,7 +2070,12 @@ piton_version = "4.7x" -- 2025/07/10
 % the standard command \texttt{\textbackslash label} in the environments
 % \texttt{\{Piton\}}. Therefore, incompatibilities may occur with extensions
 % which redefine (globally) that command \texttt{\textbackslash label} (for
-% example: \pkg{varioref}, \pkg{refcheck}, \pkg{showlabels}, etc.)}
+% example: \pkg{varioref}, \pkg{refcheck}, \pkg{showlabels}, etc.).} The same goes
+% for the |\zlabel| command from the \pkg{zref} package.\footnote{Using the
+% command \texttt{\textbackslash zcref} command from \pkg{zref-clever} is also 
+% supported.} The global option |label-as-zlabel| of \pkg{piton} allows to use
+% the command |\zlabel| as a synonym of |\label| in LaTeX comments of |Piton|
+% environments.
 %
 % \subsubsection{The key ``math-comments''}
 %
@@ -3873,7 +3878,12 @@ piton_version = "4.7x" -- 2025/07/10
 \bool_new:N \g_@@_beamer_bool
 %    \end{macrocode}
 %
-%
+% The key |label-as-zlabel| will be used to indicate if the user wants |\label|
+% inside |Piton| environments to be replaced by a |\zlabel|-compatible command
+% (which is the default behavior of \pkg{zref} outside of such environments).
+%    \begin{macrocode}
+\bool_new:N \g__piton_zlabel_as_label_bool
+%    \end{macrocode}
 % 
 % \bigskip
 % We define a set of keys for the options at load-time.
@@ -3889,18 +3899,24 @@ piton_version = "4.7x" -- 2025/07/10
     beamer .default:n = true , 
     beamer .usage:n = load ,
 
+    label-as-zlabel .bool_gset:N = \g__@@_zlabel_as_label_bool ,
+    label-as-zlabel .default:n = true ,
+    label-as-zlabel .initial:n = false ,
+    label-as-zlabel .usage:n = load ,
+
     unknown .code:n = \@@_error:n { Unknown~key~for~package }
   }
 %    \end{macrocode}
 % 
 %    \begin{macrocode}
-\@@_msg_new:nn { Unknown~key~for~package }
+\__piton_msg_new:nn { Unknown~key~for~package }
   {
     Unknown~key.\\
     You~have~used~the~key~'\l_keys_key_str'~when~loading~piton~
     but~the~only~keys~available~here~
-    are~'beamer',~'footnote',~and~'footnotehyper'.~
-    Other~keys~are~available~in~\token_to_str:N \PitonOptions.\\ 
+    are~'beamer',~'footnote','footnotehyper'~and~
+    'label-as-zlabel'.~ Other~keys~are~available~in~
+    \token_to_str:N \PitonOptions.\\
     That~key~will~be~ignored.
   }
 %    \end{macrocode}
@@ -3924,6 +3940,25 @@ piton_version = "4.7x" -- 2025/07/10
   }
 %    \end{macrocode}
 %
+% \bigskip
+% If the |label-as-zlabel| key is set to |true| while the |zref| package is not
+% loaded, an error is raised.
+%    \begin{macrocode}
+\__@@_msg_new:nn { label~as~zlabel~needs~zref~package }
+  {
+    The~key~'label-as-zlabel'~requires~the~package~'zref'.~
+    Please~load~the~package~'zref'.
+  }
+\hook_gput_code:nnn { begindocument } { . }
+  {
+    \bool_if:NT \g__piton_zlabel_as_label_bool
+    {
+      \IfPackageLoadedTF { zref-base }
+      { }
+      { \__@@_error:n { label~as~zlabel~needs~zref~package } }
+    }
+  }
+%    \end{macrocode}
 %    \begin{macrocode}
 \lua_now:e
   { 
@@ -4414,12 +4449,39 @@ piton_version = "4.7x" -- 2025/07/10
             } 
           } 
         \@esphack
-        \@ifpackageloaded{hyperref}{\Hy@raisedlink{\hyper@anchorstart{line.#1}\hyper@anchorend}}{}
+        \IfPackageLoadedTF{hyperref}{\Hy@raisedlink{\hyper@anchorstart{line.#1}\hyper@anchorend}}{}
       }
       { \@@_error:n { label~with~lines~numbers } }
   }
 %    \end{macrocode}
 %
+% \bigskip
+% 
+% The same goes for the command |\zlabel| if the |zref| package is loaded.
+% Note that |\label| will also be linked to |\@@_zlabel:n| if the key
+% |label-as-zlabel| is set to |true|.
+%    \begin{macrocode}
+\cs_new_protected:Npn \__@@_zlabel:n #1
+  {
+    \bool_if:NTF \l__@@_line_numbers_bool
+      {
+        \@bsphack
+        \protected@write \@auxout { }
+          {
+            \string\zref@newlabel {#1}{%
+              \string\default{\number\g__@@_visual_line_int}%
+              \string\page{\thepage}%
+              \string\zc@type{line}%
+              \string\anchor{line.#1}%
+            }%
+          }
+        \@esphack
+        \IfPackageLoadedTF{hyperref}{\Hy@raisedlink{\hyper@anchorstart{line.#1}\hyper@anchorend}}{}
+      }
+      { \__@@_error:n { label~with~lines~numbers } }
+  }
+%    \end{macrocode}
+% 
 % \bigskip
 % The following commands corresponds to the keys |marker/beginning| and
 % |marker/end|. The values of that keys are functions that will be applied to
@@ -5725,8 +5787,15 @@ piton_version = "4.7x" -- 2025/07/10
     \int_gzero:N \g_@@_line_int
     \int_gzero:N \g_@@_nb_lines_int
     \dim_zero:N \parindent 
-    \dim_zero:N \lineskip 
-    \cs_set_eq:NN \label \@@_label:n
+    \dim_zero:N \lineskip
+    \IfPackageLoadedTF{zref-base}{%
+      \bool_if:NTF { \g__@@_zlabel_as_label_bool }
+        { \cs_set_eq:NN \label \__@@_zlabel:n }
+        { \cs_set_eq:NN \label \__@@_label:n }%
+    }{%
+      \cs_set_eq:NN \label \__@@_label:n
+    }
+    \IfPackageLoadedTF{zref-base}{\cs_set_eq:NN \zlabel \__@@_zlabel:n}{}
     \dim_zero:N \parskip
     \l_@@_font_command_tl
   }

--- a/piton.sty
+++ b/piton.sty
@@ -2097,7 +2097,8 @@
 \__piton_msg_new:nn { label~with~lines~numbers }
   {
     You~can't~use~the~command~\token_to_str:N \label\
-    because~the~key~'line-numbers'~is~not~active.\\
+    or~\token_to_str:N \zlabel\ because~the~key~'line-numbers'
+    ~is~not~active.\\
     If~you~go~on,~that~command~will~ignored.
   }
 \__piton_msg_new:nn { overlay~without~beamer }

--- a/piton.sty
+++ b/piton.sty
@@ -100,6 +100,7 @@
 \bool_new:N \g__piton_footnotehyper_bool
 \bool_new:N \g__piton_footnote_bool
 \bool_new:N \g__piton_beamer_bool
+\bool_new:N \g__piton_zlabel_as_label_bool
 \keys_define:nn { piton }
   {
     footnote .bool_gset:N = \g__piton_footnote_bool ,
@@ -111,6 +112,11 @@
     beamer .default:n = true ,
     beamer .usage:n = load ,
 
+    label-as-zlabel .bool_gset:N = \g__piton_zlabel_as_label_bool ,
+    label-as-zlabel .default:n = true ,
+    label-as-zlabel .initial:n = false ,
+    label-as-zlabel .usage:n = load ,
+
     unknown .code:n = \__piton_error:n { Unknown~key~for~package }
   }
 \__piton_msg_new:nn { Unknown~key~for~package }
@@ -118,8 +124,9 @@
     Unknown~key.\\
     You~have~used~the~key~'\l_keys_key_str'~when~loading~piton~
     but~the~only~keys~available~here~
-    are~'beamer',~'footnote',~and~'footnotehyper'.~
-    Other~keys~are~available~in~\token_to_str:N \PitonOptions.\\
+    are~'beamer',~'footnote','footnotehyper'~and~
+    'label-as-zlabel'.~ Other~keys~are~available~in~
+    \token_to_str:N \PitonOptions.\\
     That~key~will~be~ignored.
   }
 \ProcessKeyOptions
@@ -129,6 +136,20 @@
     \IfPackageLoadedTF { beamerarticle }
     { \bool_gset_true:N \g__piton_beamer_bool }
     { }
+  }
+\__piton_msg_new:nn { label~as~zlabel~needs~zref~package }
+  {
+    The~key~'label-as-zlabel'~requires~the~package~'zref'.~
+    Please~load~the~package~'zref'.
+  }
+\hook_gput_code:nnn { begindocument } { . }
+  {
+    \bool_if:NT \g__piton_zlabel_as_label_bool
+    {
+      \IfPackageLoadedTF { zref-base }
+      { }
+      { \__piton_error:n { label~as~zlabel~needs~zref~package } }
+    }
   }
 \lua_now:e
   {
@@ -275,7 +296,26 @@
             }
           }
         \@esphack
-        \@ifpackageloaded{hyperref}{\Hy@raisedlink{\hyper@anchorstart{line.#1}\hyper@anchorend}}{}
+        \IfPackageLoadedTF{hyperref}{\Hy@raisedlink{\hyper@anchorstart{line.#1}\hyper@anchorend}}{}
+      }
+      { \__piton_error:n { label~with~lines~numbers } }
+  }
+\cs_new_protected:Npn \__piton_zlabel:n #1
+  {
+    \bool_if:NTF \l__piton_line_numbers_bool
+      {
+        \@bsphack
+        \protected@write \@auxout { }
+          {
+            \string\zref@newlabel {#1}{%
+              \string\default{\number\g__piton_visual_line_int}%
+              \string\page{\thepage}%
+              \string\zc@type{line}%
+              \string\anchor{line.#1}%
+            }%
+          }
+        \@esphack
+        \IfPackageLoadedTF{hyperref}{\Hy@raisedlink{\hyper@anchorstart{line.#1}\hyper@anchorend}}{}
       }
       { \__piton_error:n { label~with~lines~numbers } }
   }
@@ -1051,7 +1091,14 @@
     \int_gzero:N \g__piton_nb_lines_int
     \dim_zero:N \parindent
     \dim_zero:N \lineskip
-    \cs_set_eq:NN \label \__piton_label:n
+    \IfPackageLoadedTF{zref-base}{%
+      \bool_if:NTF { \g__piton_zlabel_as_label_bool }
+        { \cs_set_eq:NN \label \__piton_zlabel:n }
+        { \cs_set_eq:NN \label \__piton_label:n }%
+    }{%
+      \cs_set_eq:NN \label \__piton_label:n
+    }
+    \IfPackageLoadedTF{zref-base}{\cs_set_eq:NN \zlabel \__piton_zlabel:n}{}
     \dim_zero:N \parskip
     \l__piton_font_command_tl
   }


### PR DESCRIPTION
Bonjour !

Ce pull request contient trois propositions de changements :

- une petite correction dans la définition de `\__piton_label` pour qu'il utilise `\IfPackageLoadedTF`, comme le reste du paquetage, plutôt que ``\@ifpackageloaded` que je proposais dans #15.
- l'ajout d'une définition similaire `\__piton_zlabel` qui imite le comportement de `\zlabel` du paquetage [zref](https://ctan.org/pkg/zref), avec les informations nécessaires pour supporter la commande `\zcref` du paquetage [zref-clever](https://ctan.org/pkg/zref-clever).
- l'ajout d'une option globale `label-as-zlabel` permettant qu'à l'intérieur d'un environnement `{Piton}`, `\label` appelle la commande `\__piton_zlabel` plutôt que `\__piton_label` : c'est le comportement normal du paquetage `\zref` qui modifie lui aussi la commande `\label` par défaut. Un message d'erreur est prévu dans le cas où cette option est utilisée sans que `zref` ne soit chargé.

Par exemple, le code suivant peut maintenant compiler :

```latex
\documentclass{article}

\usepackage[french]{babel}

\usepackage{zref-clever}
\usepackage[label-as-zlabel]{piton}
\usepackage{hyperref}

\PitonOptions{
  begin-escape=(*>,
  end-escape=*)
}

\begin{document}

\begin{Piton}[line-numbers]
def f(x):
    return x + 1 #> \label{test1}
\end{Piton}

\zcref{test1}

\begin{Piton}[language=OCaml, line-numbers]
let x = 0 (*> \label{test2} *)
let y = 1 (*> \label{test3} *)
let z = x + y
let f a b = a + b
\end{Piton}

\zcref{test2, test3}

\end{document}
```

N'hésitez pas si vous avez des retours !
