### PR TITLE
Moved label-as-zlabel from global options to PitonOptions (in preamble)

### DIFF
--- a/piton.dtx
+++ b/piton.dtx
@@ -5787,7 +5787,7 @@ piton_version = "4.7x" -- 2025/07/10
     \dim_zero:N \lineskip
     \IfPackageLoadedTF { zref-base }
       {
-        \bool_if:NTF \g_@@_label_as_zlabel_bool 
+        \bool_if:NTF \l_@@_label_as_zlabel_bool 
           { \cs_set_eq:NN \label \@@_zlabel:n }
           { \cs_set_eq:NN \label \@@_label:n }
         \cs_set_eq:NN \zlabel \@@_zlabel:n

--- a/piton.sty
+++ b/piton.sty
@@ -1089,7 +1089,7 @@
     \dim_zero:N \lineskip
     \IfPackageLoadedTF { zref-base }
       {
-        \bool_if:NTF \g__piton_label_as_zlabel_bool
+        \bool_if:NTF \l__piton_label_as_zlabel_bool
           { \cs_set_eq:NN \label \__piton_zlabel:n }
           { \cs_set_eq:NN \label \__piton_label:n }
         \cs_set_eq:NN \zlabel \__piton_zlabel:n


### PR DESCRIPTION
Bonjour !

Voici ma proposition pour déplacer l'appel à l'option `label-as-zlabel` vers un appel à `\PitonOptions` dans le préambule.

J'espère que c'est plus idiomatique comme ça. N'hésitez pas si vous avez des remarques.