### PR TITLE
Fixed `\rowcolor` undefined inside of `piton` commands

### DIFF
--- a/piton.dtx
+++ b/piton.dtx
@@ -5867,6 +5867,15 @@ piton_version = "4.8x" -- 2025/08/09
 %
 %    \begin{macrocode}
     \cs_set_eq:NN \@@_begin_line: \prg_do_nothing:
+%    \end{macrocode}
+%    
+%    \bigskip
+%    We redefine |\rowcolor| inside of |\piton| commands to do nothing.
+%    \begin{macrocode}
+    \cs_set:Npn \rowcolor ##1 {}
+%    \end{macrocode}
+%    
+%    \begin{macrocode}
     \tl_set:Ne \l_tmpa_tl 
       { 
         \lua_now:e 
@@ -5904,6 +5913,15 @@ piton_version = "4.8x" -- 2025/08/09
     \group_begin:
     \automatichyphenmode = 1
     \cs_set_eq:NN \@@_begin_line: \prg_do_nothing:
+%    \end{macrocode}
+%    
+%    \bigskip
+%    We redefine |\rowcolor| inside of |\piton| commands to do nothing.
+%    \begin{macrocode}
+    \cs_set:Npn \rowcolor ##1 {}
+%    \end{macrocode}
+%    
+%    \begin{macrocode}
     \tl_set:Ne \l_tmpa_tl 
       { 
         \lua_now:e 

--- a/piton.sty
+++ b/piton.sty
@@ -1028,6 +1028,7 @@
     \cs_set_eq:NN \$ \c_dollar_str
     \cs_set_eq:cN { ~ } \space
     \cs_set_eq:NN \__piton_begin_line: \prg_do_nothing:
+    \cs_set:Npn \rowcolor ##1 {}
     \tl_set:Ne \l_tmpa_tl
       {
         \lua_now:e
@@ -1052,6 +1053,7 @@
     \group_begin:
     \automatichyphenmode = 1
     \cs_set_eq:NN \__piton_begin_line: \prg_do_nothing:
+    \cs_set:Npn \rowcolor ##1 {}
     \tl_set:Ne \l_tmpa_tl
       {
         \lua_now:e


### PR DESCRIPTION
Bonjour !

Ce pull request vise à corriger #20 : elle vise à redéfinir à l'intérieur des commandes `\piton` la commande `\rowcolor` pour qu'elle ne fasse rien. Cette solution suppose que l'on ne veut pas coloriser un prompt dans une commande `\piton`, ce qui est de mémoire le comportement préexistant à la version 4.8.

N'hésitez pas si vous avez des remarques !