### PR TITLE
Convertir les identifiants en str avant de les donner à csname

### DIFF
--- a/piton.sty
+++ b/piton.sty
@@ -2122,11 +2122,13 @@
           { \cs_set:cpn { PitonIdentifier _ \l_tmpa_str _ ##1 } { #3 } }
       }
   }
+\cs_new:Nn \__piton_fullexpand_to:nN {\exp_args:NNo \str_set:Nn #2 {\tl_to_str:n {#1}}}
 \cs_new_protected:Npn \__piton_identifier:n #1
   {
-    \cs_if_exist_use:cF { PitonIdentifier _ \l_piton_language_str _ #1 }
+    \__piton_fullexpand_to:nN { #1 } \l_tmpa_str
+    \cs_if_exist_use:cF { PitonIdentifier _ \l_piton_language_str _ \l_tmpa_str }
       {
-        \cs_if_exist_use:cF { PitonIdentifier _ #1 }
+        \cs_if_exist_use:cF { PitonIdentifier _ \l_tmpa_str }
           { \PitonStyle { Identifier } }
       }
     { #1 }
@@ -2134,11 +2136,12 @@
 \cs_new_protected:cpn { pitonStyle _ Name.Function.Internal } #1
   {
     { \PitonStyle { Name.Function } { #1 } }
-    \cs_gset_protected:cpn { PitonIdentifier _ \l_piton_language_str _ #1 }
+    \__piton_fullexpand_to:nN { #1 } \l_tmpa_str
+    \cs_gset_protected:cpn { PitonIdentifier _ \l_piton_language_str _ \l_tmpa_str }
       { \PitonStyle { UserFunction } }
     \seq_if_exist:cF { g__piton_functions _ \l_piton_language_str _ seq }
       { \seq_new:c { g__piton_functions _ \l_piton_language_str _ seq } }
-    \seq_gput_right:cn { g__piton_functions _ \l_piton_language_str _ seq } { #1 }
+    \seq_gput_right:cn { g__piton_functions _ \l_piton_language_str _ seq } { \l_tmpa_str }
     \seq_if_in:NoF \g__piton_languages_seq { \l_piton_language_str }
       { \seq_gput_left:No \g__piton_languages_seq { \l_piton_language_str } }
   }


### PR DESCRIPTION
Pour expliquer la façon dont on écrit une définition de fonction en OCaml, je me suis retrouvé à faire (avec mathescape)

```latex
\begin{Piton}[language=OCaml]
let $\mathit{nomFonction}$ $\mathit{nomParamètre}$ =
  $\mathit{corpsFonction}$
\end{Piton}
```

Malgré l'utilisation de unicode-math, ça ne fonctionne pas parce que les noms de fonction et les arguments ont un traitement spécial qui passe par un ``\csname``. Je propose de stringifier l'argument avant de le faire (en tout cas ça marche pour le cas ci-dessus).

Il y a peut-être des changements à faire ailleurs, c'est une partie du code que je ne comprends pas.