### PR TITLE
Gérer le type 'a ref correctement

### DIFF
--- a/piton.sty
+++ b/piton.sty
@@ -1918,7 +1918,7 @@
   {
     TypeExpression =
       {
-        \SetPitonStyle [ OCaml ] { Identifier = \PitonStyle { Name.Type } }
+        \SetPitonStyle [ OCaml ] { Identifier = \PitonStyle { Name.Type }, Name.Builtin = \PitonStyle { Name.Type} }
         \__piton_piton:n
       }
   }


### PR DESCRIPTION
En OCaml, on a la fonction ``ref``, qui est identifié comme Builtin par piton, et le type ``'a ref`` qui doit être typographié comme un type. Il faut donc renforcer un peu l'astuce qui a été choisie pour le style des types.