### PR TITLE
Added some C types and fixed a bug with type parsing

### DIFF
--- a/piton-code.dtx
+++ b/piton-code.dtx
@@ -6869,15 +6869,16 @@ do
 
   local Type = 
     K ( 'Name.Type' ,
-        P "bool" + "char" + "char16_t" + "char32_t" + "double" + "float" +
+        P "FILE" + "bool" + "char" + "char16_t" + "char32_t" + "clock_t" +
+        "double" + "float" + "fpos_t" +
         "int8_t" + "int16_t" + "int32_t" + "int64_t" + "uint8_t" + "uint16_t" +
         "uint32_t" + "uint64_t" + "int" + "long" + "short" + "signed" + "unsigned" +
-        "size_t" + "void" + "wchar_t" ) * Q "*" ^ 0 
+        "ptrdiff_t" + "size_t" + "time_t" + "void" + "wchar_t" )
+    * -alphanum * Space ^ 0 * Q "*" ^ 0
 
   local DefFunction = 
-    Type 
-    * Space 
-    * Q "*" ^ -1
+    Type
+    * Space ^ 0
     * K ( 'Name.Function.Internal' , identifier ) 
     * SkipSpace 
     * # P "("
@@ -6995,15 +6996,15 @@ do
        + Beamer
        + DetectedCommands
        + Preproc
-       + Comment + LongComment
-       + Delim
-       + Operator
+        + Comment + LongComment
+        + Delim
+        + Operator
        + Character
        + String
        + Punct
        + DefFunction
        + DefClass 
-       + Type * ( Q "*" ^ -1 + EndKeyword ) 
+        + Type
        + Keyword * EndKeyword
        + Builtin * EndKeyword
        + Identifier 

--- a/piton-code.dtx
+++ b/piton-code.dtx
@@ -6872,7 +6872,7 @@ do
         P "bool" + "char" + "char16_t" + "char32_t" + "double" + "float" +
         "int8_t" + "int16_t" + "int32_t" + "int64_t" + "uint8_t" + "uint16_t" +
         "uint32_t" + "uint64_t" + "int" + "long" + "short" + "signed" + "unsigned" +
-        "void" + "wchar_t" ) * Q "*" ^ 0 
+        "size_t" + "void" + "wchar_t" ) * Q "*" ^ 0 
 
   local DefFunction = 
     Type 

--- a/piton-french.tex
+++ b/piton-french.tex
@@ -4242,9 +4242,10 @@ String.Interpol & les éléments \texttt{\%d}, \texttt{\%i}, \texttt{\%f}, \text
                   etc. dans les chaînes de caractères ; ce style hérite du style
                   |String.Long| \\ 
 Operator & les opérateurs suivants : \texttt{!= == << >> - \~{} + / * \% = < > \& .} \verb+|+ |@| \\ % |
-Name.Type & les types prédéfinis suivants : |bool|, |char|, |char16_t|, |char32_t|,
-            |double|, |float|, |int|, |int8_t|, |int16_t|, |int32_t|, |int64_t|, |long|,
-            |short|, |signed|, |unsigned|, |void| et |wchar_t| \\  
+Name.Type & les types prédéfinis suivants : |FILE|, |bool|, |char|, |char16_t|,
+            |char32_t|, |clock_t|, |double|, |float|, |fpos_t|, |int8_t|, |int16_t|,
+            |int32_t|, |int64_t|, |uint8_t|, |uint16_t|, |uint32_t|, |uint64_t|, |int|, |long|,
+            |short|, |signed|, |unsigned|, |ptrdiff_t|, |size_t|, |time_t|, |void| et |wchar_t| \\  
 Name.Builtin & les fonctions prédéfinies suivantes : |printf|, |scanf|, |malloc|, |sizeof|
                et  |alignof|  \\ 
 Name.Class & le nom des classes au moment de leur définition, c'est-à-dire après le

--- a/piton.lua
+++ b/piton.lua
@@ -1042,15 +1042,16 @@ do
 
   local Type =
     K ( 'Name.Type' ,
-        P "bool" + "char" + "char16_t" + "char32_t" + "double" + "float" +
+        P "FILE" + "bool" + "char" + "char16_t" + "char32_t" + "clock_t" +
+        "double" + "float" + "fpos_t" +
         "int8_t" + "int16_t" + "int32_t" + "int64_t" + "uint8_t" + "uint16_t" +
         "uint32_t" + "uint64_t" + "int" + "long" + "short" + "signed" + "unsigned" +
-        "void" + "wchar_t" ) * Q "*" ^ 0
+        "ptrdiff_t" + "size_t" + "time_t" + "void" + "wchar_t" )
+    * -alphanum * Space ^ 0 * Q "*" ^ 0
 
   local DefFunction =
     Type
-    * Space
-    * Q "*" ^ -1
+    * Space ^ 0
     * K ( 'Name.Function.Internal' , identifier )
     * SkipSpace
     * # P "("
@@ -1100,15 +1101,15 @@ do
        + Beamer
        + DetectedCommands
        + Preproc
-       + Comment + LongComment
-       + Delim
-       + Operator
+        + Comment + LongComment
+        + Delim
+        + Operator
        + Character
        + String
        + Punct
        + DefFunction
        + DefClass
-       + Type * ( Q "*" ^ -1 + EndKeyword )
+        + Type
        + Keyword * EndKeyword
        + Builtin * EndKeyword
        + Identifier

--- a/piton.tex
+++ b/piton.tex
@@ -4191,9 +4191,10 @@ String.Interpol &  the elements \texttt{\%d}, \texttt{\%i}, \texttt{\%f},
 Operator & the following operators : 
 \texttt{!= == << >> - \~{} + / * \% = < > \& .} \verb+|+ \verb|@| \\ 
 Name.Type & the following predefined types:
-  |bool|, |char|, |char16_t|, |char32_t|, |double|, |float|, |int|, |int8_t|,
-  |int16_t|, |int32_t|, |int64_t|, |uint8_t|, |uint16_t|, |uint32_t|, |uint64_t|,
-  |long|, |short|, |signed|, |unsigned|, |void| et |wchar_t| \\  
+  |FILE|, |bool|, |char|, |char16_t|, |char32_t|, |clock_t|, |double|, |float|,
+  |fpos_t|, |int8_t|, |int16_t|, |int32_t|, |int64_t|, |uint8_t|, |uint16_t|,
+  |uint32_t|, |uint64_t|, |int|, |long|, |short|, |signed|, |unsigned|,
+  |ptrdiff_t|, |size_t|, |time_t|, |void| et |wchar_t| \\  
 Name.Builtin & the following predefined functions: |printf|, |scanf|,
 |malloc|, |sizeof| and |alignof|  \\ 
 Name.Class & the names of the classes when they are defined, that is to say after


### PR DESCRIPTION
Add missing C predefined types (`FILE, clock_t, fpos_t, ptrdiff_t, time_t, size_t`) and improve parsing of types to not print as types identifiers in which a type name (eg. `integral`) is a factor.