### PR TITLE
Fix in OCaml records parsing, added short field notation support

### DIFF
--- a/piton-code.dtx
+++ b/piton-code.dtx
@@ -6481,9 +6481,7 @@ do
 % |{ field = field }|.
 %    \begin{macrocode}
     * (
-          Q "=" * SkipSpace
-%    \end{macrocode}
-%    \begin{macrocode}
+        Q "=" * SkipSpace
         * ( C ( expression_for_fields_value ) / ParseAgain )
         * SkipSpace
       + P ""

--- a/piton-code.dtx
+++ b/piton-code.dtx
@@ -6476,12 +6476,18 @@ do
 %    \begin{macrocode}
   local OneField =
       K ( 'Name.Field' , identifier ) * SkipSpace
-    * Q "=" * SkipSpace
 %    \end{macrocode}
-% Don't forget the parentheses!
+% A value field may use OCaml's abbreviated syntax: |{ field }| means
+% |{ field = field }|.
 %    \begin{macrocode}
-    * ( C ( expression_for_fields_value ) / ParseAgain ) 
-    * SkipSpace
+    * (
+          Q "=" * SkipSpace
+%    \end{macrocode}
+%    \begin{macrocode}
+        * ( C ( expression_for_fields_value ) / ParseAgain )
+        * SkipSpace
+      + P ""
+      )
 %    \end{macrocode}
 %
 % \bigskip

--- a/piton.lua
+++ b/piton.lua
@@ -784,9 +784,12 @@ do
     * SkipSpace
   local OneField =
       K ( 'Name.Field' , identifier ) * SkipSpace
-    * Q "=" * SkipSpace
-    * ( C ( expression_for_fields_value ) / ParseAgain )
-    * SkipSpace
+    * (
+          Q "=" * SkipSpace
+        * ( C ( expression_for_fields_value ) / ParseAgain )
+        * SkipSpace
+      + P ""
+      )
   local RecordVal =
     Q "{" * SkipSpace
     *

--- a/piton.lua
+++ b/piton.lua
@@ -785,7 +785,7 @@ do
   local OneField =
       K ( 'Name.Field' , identifier ) * SkipSpace
     * (
-          Q "=" * SkipSpace
+        Q "=" * SkipSpace
         * ( C ( expression_for_fields_value ) / ParseAgain )
         * SkipSpace
       + P ""


### PR DESCRIPTION
Adds support for short notation in OCaml records, where one can omit to write the field value if it is a variable with the same name as the field.